### PR TITLE
Split "running workshops"

### DIFF
--- a/content/04-running-workshops.md
+++ b/content/04-running-workshops.md
@@ -21,46 +21,7 @@ keypoints:
 {: .callout}
 
 
-# Organize a CodeRefinery workshop
-
-You or us?
-- Historically, most workshops are CodeRefinery workshops were
-  organized centrally with a local host.
-- Now, we want to transition to locally-invited workshops, so we know
-  we have a audience and advertisement.
-- In the future, we need to transition to "independently run".
-
-Anyone can organize a CodeRefinery workshop and teach the CodeRefinery lessons which are
-licensed under [CC-BY](https://creativecommons.org/licenses/by/4.0/).
-However, making it a successful workshop requires careful planning and preparation. Here we will go
-through practical aspects of organizing a workshop.
-
-## Centrally organized workshops
-
-- CodeRefinery staff organize, we try to reach as many people as
-  possible.
-- Workshops in our own institutions tend to be best-attended, going to
-  a new institution sometimes has low attendance.
-- We started this way.
-
-
-## Locally invited workshops
-
-- A local team requests CodeRefinery (usually with a known audience).
-- There is usually pretty good attendance.
-- CodeRefinery staff travels to site and teaches - at least with local
-  helpers, ideally with a local instructor.
-
-## Independently organized workshops
-
-- In the future, we want to encourage independently organized
-  workshops: a site can organize the workshops without needing to go
-  through the core team.
-- We don't yet know exactly how this will work, but this instructor
-  training is part of it.
-
-
-## How to run a successful workshop: CodeRefinery or otherwise
+## Running a workshop
 
 
 ### Arranging the workshop

--- a/content/coderefinery-workshops.md
+++ b/content/coderefinery-workshops.md
@@ -1,0 +1,37 @@
+# Organize a CodeRefinery workshop
+
+You or us?
+- Historically, most workshops are CodeRefinery workshops were
+  organized centrally with a local host.
+- Now, we want to transition to locally-invited workshops, so we know
+  we have a audience and advertisement.
+- In the future, we need to transition to "independently run".
+
+Anyone can organize a CodeRefinery workshop and teach the CodeRefinery lessons which are
+licensed under [CC-BY](https://creativecommons.org/licenses/by/4.0/).
+However, making it a successful workshop requires careful planning and preparation. Here we will go
+through practical aspects of organizing a workshop.
+
+## Centrally organized workshops
+
+- CodeRefinery staff organize, we try to reach as many people as
+  possible.
+- Workshops in our own institutions tend to be best-attended, going to
+  a new institution sometimes has low attendance.
+- We started this way.
+
+
+## Locally invited workshops
+
+- A local team requests CodeRefinery (usually with a known audience).
+- There is usually pretty good attendance.
+- CodeRefinery staff travels to site and teaches - at least with local
+  helpers, ideally with a local instructor.
+
+## Independently organized workshops
+
+- In the future, we want to encourage independently organized
+  workshops: a site can organize the workshops without needing to go
+  through the core team.
+- We don't yet know exactly how this will work, but this instructor
+  training is part of it.

--- a/content/index.rst
+++ b/content/index.rst
@@ -19,11 +19,12 @@ Intro
    xx min ; :doc:`01-intro`
    xx min ; :doc:`02-teaching-philosophies`
    xx min ; :doc:`03-teaching-style`
-   xx min ; :doc:`04-running-workshops`
+   25 min ; :doc:`04-running-workshops`
    20 min ; :doc:`lesson-design`
    30 min ; :doc:`lesson-development`
    xx min ; :doc:`06-teaching`
    xx min ; :doc:`07-future`
+    5 min ; :doc:`coderefinery-workshops`
 
 
 .. toctree::


### PR DESCRIPTION
- Split it into two episodes:
  - Running workshops (generic, longer)
  - How to invite a CodeRefinery workshop (short)
- No other content changes.
- CodeRefinery is currently at the end, but can be moved.  It's not
  linked from our schedule yet.
- This will cause some Sphinx errors, which I will fix (along with
  others) in a future PR.
- Review: is splitting a good idea?